### PR TITLE
updated final access token key name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Handling the Callback
 
     access_token = f.get_access_token(code)
     
-    final_access_token = access_token['oauth_token']
+    final_access_token = access_token['access_token']
     
     # Save that token to the database for a later use?
 


### PR DESCRIPTION
as described here: https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/v2.2
under "Exchanging code for an access token", the response will contain the final access token keyed as 'access_token' instead of 'oauth-token'.